### PR TITLE
Prepare v1.0.0 release

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -2,3 +2,6 @@
 ^\.Rproj\.user$
 ^LICENSE\.md$
 ^README\.Rmd$
+^\.github$
+^.*\.Rcheck$
+^biooracler_.*\.tar\.gz$

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -1,0 +1,52 @@
+# Workflow derived from https://github.com/r-lib/actions/tree/v2/examples
+# Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
+on:
+  push:
+    branches: [main, master]
+  pull_request:
+    branches: [main, master]
+
+name: R-CMD-check.yaml
+
+permissions: read-all
+
+jobs:
+  R-CMD-check:
+    runs-on: ${{ matrix.config.os }}
+
+    name: ${{ matrix.config.os }} (${{ matrix.config.r }})
+
+    strategy:
+      fail-fast: false
+      matrix:
+        config:
+          - {os: macos-latest,   r: 'release'}
+          - {os: windows-latest, r: 'release'}
+          - {os: ubuntu-latest,  r: 'devel', http-user-agent: 'release'}
+          - {os: ubuntu-latest,  r: 'release'}
+          - {os: ubuntu-latest,  r: 'oldrel-1'}
+
+    env:
+      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+      R_KEEP_PKG_SOURCE: yes
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: r-lib/actions/setup-pandoc@v2
+
+      - uses: r-lib/actions/setup-r@v2
+        with:
+          r-version: ${{ matrix.config.r }}
+          http-user-agent: ${{ matrix.config.http-user-agent }}
+          use-public-rspm: true
+
+      - uses: r-lib/actions/setup-r-dependencies@v2
+        with:
+          extra-packages: any::rcmdcheck
+          needs: check
+
+      - uses: r-lib/actions/check-r-package@v2
+        with:
+          upload-snapshots: true
+          build_args: 'c("--no-manual","--compact-vignettes=gs+qpdf")'

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,18 +1,18 @@
 Package: biooracler
-Title: Import environmental ocean data from Bio-Oracle via ERDDAP
-Version: 0.0.0.9000
+Title: Import Environmental Ocean Data from Bio-Oracle via ERDDAP
+Version: 1.0.0
 Authors@R: c(
       person("Salvador", "Fernandez", email = "salvador.fernandez@vliz.be", role = c("aut", "cre")),
-      person("Vinicius", "Salazar", role = c("ctb")))
-Description: Environmental ocean data modeled both for the present and for future climate change 
-             scenarios offered by the Bio-Oracle dataset <https://bio-oracle.org/> via ERDDAP server. 
+      person("Vinicius", "Salazar", email = "viniws@gmail.com", role = "aut"))
+Description: Environmental ocean data modeled both for the present and for future climate change
+             scenarios offered by the Bio-Oracle dataset <https://bio-oracle.org/> via ERDDAP server.
 License: MIT + file LICENSE
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.2.3
-URL: https://bio-oracle.org/; https://erddap.bio-oracle.org/
-Suggests: 
-    httr,
+RoxygenNote: 7.3.3
+URL: https://bio-oracle.org/, https://erddap.bio-oracle.org/
+BugReports: https://github.com/bio-oracle/biooracler/issues
+Suggests:
     testthat (>= 3.0.0)
 Config/testthat/edition: 3
 Imports: 

--- a/LICENSE
+++ b/LICENSE
@@ -1,2 +1,2 @@
-YEAR: 2022
+YEAR: 2022-2026
 COPYRIGHT HOLDER: biooracler authors

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,6 @@
 # MIT License
 
-Copyright (c) 2022 biooracler authors
+Copyright (c) 2022-2026 biooracler authors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/NAMESPACE
+++ b/NAMESPACE
@@ -3,3 +3,4 @@
 export(download_layers)
 export(info_layer)
 export(list_layers)
+importFrom(memoise,memoise)

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,10 +1,29 @@
-# biooracler (development version)
+# biooracler 1.0.0
+
+First stable release.
+
+## New features
 
 * `download_layers()` gains a `filename` argument to save downloaded files under a
   human-readable name instead of the cryptic cache hash (#13).
+
+## Improvements
+
 * `download_layers()` now reports clearer error messages when the Bio-Oracle ERDDAP
   server is unreachable or constraints fall outside the dataset range, and warns when
   a query returns no data (#3).
-* Documentation clarifies that the `time` constraint is a range (one layer per time
-  step within it, #18) and that the raster extent reaches half a cell beyond nominal
-  bounds because ERDDAP reports cell-center coordinates (#20).
+* The Bio-Oracle ERDDAP server is now contacted over HTTPS.
+
+## Documentation
+
+* Clarified that the `time` constraint is a range (one layer per time step within it,
+  #18) and that the raster extent reaches half a cell beyond nominal bounds because
+  ERDDAP reports cell-center coordinates (#20).
+* Fixed the `dataset_id` reference (duplicate `phyc` entry and a transposed year in an
+  example).
+
+## Infrastructure
+
+* Added a GitHub Actions `R-CMD-check` workflow across Linux, macOS and Windows.
+* Added `BugReports`, tidied `DESCRIPTION` metadata, and removed unused dependencies
+  and dead code.

--- a/R/biooracler-package.R
+++ b/R/biooracler-package.R
@@ -2,6 +2,7 @@
 "_PACKAGE"
 
 ## usethis namespace: start
+#' @importFrom memoise memoise
 ## usethis namespace: end
 NULL
 
@@ -10,13 +11,13 @@ NULL
 #'
 #' @description
 #' The [Bio-Oracle](https://bio-oracle.org/) dataset is made available via an ERDDAP
-#' server hosted by the [Flanders Marine Institute (VLIZ)](https://www.vliz.be).
+#' server hosted by the [Flanders Marine Institute (VLIZ)](https://www.vliz.be/en).
 #'
 #' ERDDAP is a data server that gives you simple, consistent way to download subsets
 #' of scientific datasets in common file formats and make graphs and maps. The Bio-Oracle
 #' ERDDAP installation is available online at:
 #'
-#' http://erddap.bio-oracle.org/erddap/
+#' https://erddap.bio-oracle.org/erddap/
 #'
 #' ERDDAP offers a REST API that can be consumed by other software For instance,
 #' there is an R package that reads data from ERDDAP named [rerddap]. This package is
@@ -55,7 +56,7 @@ NULL
 #'
 #' - `thetao_ssp119_2020_2100_depthmean`
 #'
-#' - `thetao_baseline_2020_2019_depthsurf`
+#' - `thetao_baseline_2000_2019_depthsurf`
 #'
 #'
 #' ## Environmental variable
@@ -68,7 +69,6 @@ NULL
 #' - `o2` = Dissolved Molecular Oxygen
 #' - `ph` = pH
 #' - `phyc` = Total Phytoplankton
-#' - `phyc` = Phytoplankton
 #' - `po4` = Phosphate
 #' - `si` = Silicate
 #' - `siconc` = Sea Ice Cover
@@ -84,7 +84,7 @@ NULL
 #' The part with `baseline` or `ssp119` indicates if the layer contains present or past
 #' decades, or future climate change projections under the provisions of the
 #' [Intergovernmental Panel on Climate Change](https://www.ipcc.ch/) (IPCC) 6th report. This report features the
-#' 6th generation of [Coupled Model Intercomparison Projects](https://www.carbonbrief.org/qa-how-do-climate-models-work#cmip) (CMIP6)
+#' 6th generation of [Coupled Model Intercomparison Projects](https://www.carbonbrief.org/qa-how-do-climate-models-work/#cmip) (CMIP6)
 #' and describes a few [Shared Socioeconomic Pathways](https://www.carbonbrief.org/explainer-how-shared-socioeconomic-pathways-explore-future-climate-change/) (SSPs), which are different
 #' climate change scenarios.
 #'

--- a/R/main.R
+++ b/R/main.R
@@ -19,8 +19,8 @@
 #' - `csv`: An object of class `griddap_csv`. In essence, a `data.frame` with extra info.
 #'   A csv file will be downloaded to the cache directory. See [rerddap::griddap()].
 #' - `nc`: An object of class `griddap_nc`. This is the unclassed output of [ncdf4::nc_open()].
-#'  A [NetCDF](https://www.unidata.ucar.edu/software/netcdf/) file will be downloaded to the cache directory. See [rerddap::griddap()].
-#' - `raster`: An object of class `SpatRast`, obtained by reading the [NetCDF](https://www.unidata.ucar.edu/software/netcdf/) file with `terra::rast`.
+#'  A [NetCDF](https://www.unidata.ucar.edu/software/netcdf) file will be downloaded to the cache directory. See [rerddap::griddap()].
+#' - `raster`: An object of class `SpatRast`, obtained by reading the [NetCDF](https://www.unidata.ucar.edu/software/netcdf) file with `terra::rast`.
 #'
 #' By default, downloaded files are named with a cryptic hash (as in [rerddap::griddap()]).
 #' Pass `filename` to save a human-readable copy, e.g. `filename = "chl_2040_ssp585"`. The
@@ -65,9 +65,9 @@ download_layers = function(dataset_id,
                                     verbose = TRUE,
                                     debug = FALSE
 ) {
-  # Assertions
+  # Assertions. Cheap local argument checks run first, so calls with bad
+  # arguments fail fast before contacting the ERDDAP server.
   checkmate::assert_character(dataset_id, len = 1)
-  checkmate::assert_choice(dataset_id, list_layers()$dataset_id)
   checkmate::assert_list(constraints, min.len = 1, any.missing = FALSE, unique = TRUE)
   checkmate::assert_names(names(constraints), "unique", subset.of = c("time", "longitude", "latitude"))
   checkmate::assert_character(fmt, len = 1)
@@ -75,6 +75,8 @@ download_layers = function(dataset_id,
   checkmate::assert_character(filename, len = 1, null.ok = TRUE)
   checkmate::assert_logical(verbose, len = 1)
   checkmate::assert_logical(debug, len = 1)
+  # This check queries the server for the list of available datasets.
+  checkmate::assert_choice(dataset_id, list_layers()$dataset_id)
 
   # Config
   printer = function(message, verbose=parent.frame()$verbose) {
@@ -179,7 +181,6 @@ griddap_to_terra <- function(res){
   }else{
     layers <- rerddap::ed_search_adv(..., url = erddap.bio_oracle.org())
     layers <- dplyr::bind_rows(layers$alldata)
-    attr(layers, "class")
   }
 
   # Aftermath
@@ -231,7 +232,7 @@ do_simplify <- function(df){
 #' list_layers("Ocean Temperature 2100", simplify = FALSE)
 #' list_layers("thetao_ssp119_2020_2100_depthmean")
 #' }
-list_layers <- memoise::memoise(.list_layers)
+list_layers <- memoise(.list_layers)
 
 
 #' Gets detailed information about a single Bio-Oracle layer

--- a/R/utils.R
+++ b/R/utils.R
@@ -7,10 +7,5 @@
 #'
 #' @noRd
 erddap.bio_oracle.org <- function(){
-  getOption("ERDDAP.BIO-ORACLE.URL", "http://erddap.bio-oracle.org/erddap/")
-}
-
-
-fix_memoise_cran_note <- function(){
-  f <- memoise::memoise(print(""))
+  getOption("ERDDAP.BIO-ORACLE.URL", "https://erddap.bio-oracle.org/erddap/")
 }

--- a/README.Rmd
+++ b/README.Rmd
@@ -16,17 +16,19 @@ knitr::opts_chunk$set(
 # biooracler
 
 <!-- badges: start -->
+[![R-CMD-check](https://github.com/bio-oracle/biooracler/actions/workflows/R-CMD-check.yaml/badge.svg)](https://github.com/bio-oracle/biooracler/actions/workflows/R-CMD-check.yaml)
+[![Lifecycle: stable](https://img.shields.io/badge/lifecycle-stable-brightgreen.svg)](https://lifecycle.r-lib.org/articles/stages.html#stable)
 <!-- badges: end -->
 
 `biooracler` provides access to the [Bio-Oracle](https://bio-oracle.org/) dataset via ERDDAP server. It will partly replace [sdmpredictors](https://github.com/lifewatch/sdmpredictors).
 
 ## Installation
 
-You can install the development version of biooracler from [GitHub](https://github.com/) with:
+You can install biooracler from [GitHub](https://github.com/) with:
 
 ``` r
-# install.packages("devtools")
-devtools::install_github("bio-oracle/biooracler")
+# install.packages("remotes")
+remotes::install_github("bio-oracle/biooracler")
 ```
 
 ## List Layers

--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@
 # biooracler
 
 <!-- badges: start -->
+
+[![R-CMD-check](https://github.com/bio-oracle/biooracler/actions/workflows/R-CMD-check.yaml/badge.svg)](https://github.com/bio-oracle/biooracler/actions/workflows/R-CMD-check.yaml)
+[![Lifecycle:
+stable](https://img.shields.io/badge/lifecycle-stable-brightgreen.svg)](https://lifecycle.r-lib.org/articles/stages.html#stable)
 <!-- badges: end -->
 
 `biooracler` provides access to the
@@ -13,12 +17,11 @@ partly replace
 
 ## Installation
 
-You can install the development version of biooracler from
-[GitHub](https://github.com/) with:
+You can install biooracler from [GitHub](https://github.com/) with:
 
 ``` r
-# install.packages("devtools")
-devtools::install_github("bio-oracle/biooracler")
+# install.packages("remotes")
+remotes::install_github("bio-oracle/biooracler")
 ```
 
 ## List Layers

--- a/man/ERDDAP.Rd
+++ b/man/ERDDAP.Rd
@@ -8,22 +8,22 @@ Returns a help page
 }
 \description{
 The \href{https://bio-oracle.org/}{Bio-Oracle} dataset is made available via an ERDDAP
-server hosted by the \href{https://www.vliz.be}{Flanders Marine Institute (VLIZ)}.
+server hosted by the \href{https://www.vliz.be/en}{Flanders Marine Institute (VLIZ)}.
 
 ERDDAP is a data server that gives you simple, consistent way to download subsets
 of scientific datasets in common file formats and make graphs and maps. The Bio-Oracle
 ERDDAP installation is available online at:
 
-http://erddap.bio-oracle.org/erddap/
+https://erddap.bio-oracle.org/erddap/
 
 ERDDAP offers a REST API that can be consumed by other software For instance,
-there is an R package that reads data from ERDDAP named \link{rerddap}. This package is
-the backbone behind \code{biooracler}: In fact, \code{biooracler} just wraps \link{rerddap} in a
+there is an R package that reads data from ERDDAP named \link[rerddap:rerddap]{rerddap::rerddap}. This package is
+the backbone behind \code{biooracler}: In fact, \code{biooracler} just wraps \link[rerddap:rerddap]{rerddap::rerddap} in a
 convenient way to only read data from the Bio-Oracle ERDDAP server. But the Bio-Oracle
 ERDDAP server is independent from the \code{biooracler} package.
 
 You are welcome to access the Bio-Oracle ERDDAP server in your preferred way,
-including via the \link{rerddap} R package. This will ease the combination of the
+including via the \link[rerddap:rerddap]{rerddap::rerddap} R package. This will ease the combination of the
 Bio-Oracle dataset with several other ERDDAP servers.
 
 In addition, there is a Python extension that mimics the methods of \code{biooracler}. You

--- a/man/biooracler-package.Rd
+++ b/man/biooracler-package.Rd
@@ -4,23 +4,25 @@
 \name{biooracler-package}
 \alias{biooracler}
 \alias{biooracler-package}
-\title{biooracler: Import environmental ocean data from Bio-Oracle via ERDDAP}
+\title{biooracler: Import Environmental Ocean Data from Bio-Oracle via ERDDAP}
 \description{
 Environmental ocean data modeled both for the present and for future climate change scenarios offered by the Bio-Oracle dataset \url{https://bio-oracle.org/} via ERDDAP server.
 }
 \seealso{
 Useful links:
 \itemize{
-  \item \url{https://bio-oracle.org/; https://erddap.bio-oracle.org/}
+  \item \url{https://bio-oracle.org/}
+  \item \url{https://erddap.bio-oracle.org/}
+  \item Report bugs at \url{https://github.com/bio-oracle/biooracler/issues}
 }
 
 }
 \author{
 \strong{Maintainer}: Salvador Fernandez \email{salvador.fernandez@vliz.be}
 
-Other contributors:
+Authors:
 \itemize{
-  \item Vinicius Salazar [contributor]
+  \item Vinicius Salazar \email{viniws@gmail.com}
 }
 
 }

--- a/man/dataset_id.Rd
+++ b/man/dataset_id.Rd
@@ -16,7 +16,7 @@ indicate the information included inside. For instance:
 \itemize{
 \item \code{phyc_baseline_2000_2020_depthsurf}
 \item \code{thetao_ssp119_2020_2100_depthmean}
-\item \code{thetao_baseline_2020_2019_depthsurf}
+\item \code{thetao_baseline_2000_2019_depthsurf}
 }
 \subsection{Environmental variable}{
 
@@ -30,7 +30,6 @@ Indicated the first part of the naming (e.g. \code{phyc}, \code{thetao}). The eq
 \item \code{o2} = Dissolved Molecular Oxygen
 \item \code{ph} = pH
 \item \code{phyc} = Total Phytoplankton
-\item \code{phyc} = Phytoplankton
 \item \code{po4} = Phosphate
 \item \code{si} = Silicate
 \item \code{siconc} = Sea Ice Cover
@@ -48,7 +47,7 @@ Indicated the first part of the naming (e.g. \code{phyc}, \code{thetao}). The eq
 The part with \code{baseline} or \code{ssp119} indicates if the layer contains present or past
 decades, or future climate change projections under the provisions of the
 \href{https://www.ipcc.ch/}{Intergovernmental Panel on Climate Change} (IPCC) 6th report. This report features the
-6th generation of \href{https://www.carbonbrief.org/qa-how-do-climate-models-work#cmip}{Coupled Model Intercomparison Projects} (CMIP6)
+6th generation of \href{https://www.carbonbrief.org/qa-how-do-climate-models-work/#cmip}{Coupled Model Intercomparison Projects} (CMIP6)
 and describes a few \href{https://www.carbonbrief.org/explainer-how-shared-socioeconomic-pathways-explore-future-climate-change/}{Shared Socioeconomic Pathways} (SSPs), which are different
 climate change scenarios.
 

--- a/man/download_layers.Rd
+++ b/man/download_layers.Rd
@@ -47,8 +47,8 @@ will obtain:
 \item \code{csv}: An object of class \code{griddap_csv}. In essence, a \code{data.frame} with extra info.
 A csv file will be downloaded to the cache directory. See \code{\link[rerddap:griddap]{rerddap::griddap()}}.
 \item \code{nc}: An object of class \code{griddap_nc}. This is the unclassed output of \code{\link[ncdf4:nc_open]{ncdf4::nc_open()}}.
-A \href{https://www.unidata.ucar.edu/software/netcdf/}{NetCDF} file will be downloaded to the cache directory. See \code{\link[rerddap:griddap]{rerddap::griddap()}}.
-\item \code{raster}: An object of class \code{SpatRast}, obtained by reading the \href{https://www.unidata.ucar.edu/software/netcdf/}{NetCDF} file with \code{terra::rast}.
+A \href{https://www.unidata.ucar.edu/software/netcdf}{NetCDF} file will be downloaded to the cache directory. See \code{\link[rerddap:griddap]{rerddap::griddap()}}.
+\item \code{raster}: An object of class \code{SpatRast}, obtained by reading the \href{https://www.unidata.ucar.edu/software/netcdf}{NetCDF} file with \code{terra::rast}.
 }
 
 By default, downloaded files are named with a cryptic hash (as in \code{\link[rerddap:griddap]{rerddap::griddap()}}).
@@ -58,9 +58,9 @@ extension matching \code{fmt}. The original cached file is preserved so caching 
 
 The \code{time} constraint is a \strong{range}: every time step that falls within the
 \verb{[start, end]} interval is returned as a separate layer. Decadal baseline datasets
-store snapshots on decade boundaries, so a range like \code{c('2000-01-01T00:00:00Z', '2010-01-01T00:00:00Z')}
-spans two snapshots (two layers), while \code{c('2005-01-01T00:00:00Z', '2010-01-01T00:00:00Z')}
-spans one (single layer). To get a single time step, set the start and end of \code{time} to the same value.
+store snapshots on decade boundaries, so a range like \code{c('2000-01-01T00:00:00Z', '2010-01-01T00:00:00Z')} spans two snapshots (two layers), while
+\code{c('2005-01-01T00:00:00Z', '2010-01-01T00:00:00Z')} spans one (single layer). To get a
+single time step, set the start and end of \code{time} to the same value.
 
 ERDDAP reports coordinates at cell \strong{centers}. As a result, the extent of a returned
 \code{raster} reaches half a cell-width beyond the nominal bounds (e.g. slightly past +/-180

--- a/man/info_layer.Rd
+++ b/man/info_layer.Rd
@@ -10,7 +10,7 @@ info_layer(dataset_id)
 \item{dataset_id}{An unique identifier of the dataset in \link{ERDDAP}. See \link{dataset_id}.}
 }
 \value{
-An object of class \link{info} from the \link{rerddap} package
+An object of class \link[rerddap:info]{rerddap::info} from the \link[rerddap:rerddap]{rerddap::rerddap} package
 }
 \description{
 Gets detailed information about a single Bio-Oracle layer

--- a/tests/testthat/test-validation.R
+++ b/tests/testthat/test-validation.R
@@ -1,0 +1,44 @@
+# Input validation for download_layers(). These run offline: the checks below
+# all fail before any request to the ERDDAP server is made.
+
+valid_constraints <- list(
+  time = c('2001-01-01T00:00:00Z', '2010-01-01T00:00:00Z'),
+  latitude = c(10, 11),
+  longitude = c(120, 121)
+)
+
+test_that("download_layers rejects a malformed dataset_id", {
+  expect_error(download_layers(123, constraints = valid_constraints))
+  expect_error(download_layers(c("a", "b"), constraints = valid_constraints))
+})
+
+test_that("download_layers rejects an invalid fmt", {
+  expect_error(
+    download_layers("some_id", constraints = valid_constraints, fmt = "tiff")
+  )
+  expect_error(
+    download_layers("some_id", constraints = valid_constraints, fmt = c("nc", "csv"))
+  )
+})
+
+test_that("download_layers rejects a malformed filename", {
+  expect_error(
+    download_layers("some_id", constraints = valid_constraints, filename = 1)
+  )
+  expect_error(
+    download_layers("some_id", constraints = valid_constraints,
+                    filename = c("a", "b"))
+  )
+})
+
+test_that("download_layers rejects malformed constraints", {
+  # Empty constraints
+  expect_error(download_layers("some_id", constraints = list()))
+  # Unnamed constraints
+  expect_error(download_layers("some_id", constraints = list(c(10, 11))))
+  # Unknown constraint name
+  expect_error(download_layers(
+    "some_id",
+    constraints = list(depth = c(0, 10))
+  ))
+})


### PR DESCRIPTION
Audit and polish for the first stable tag (v1.0.0).

## Metadata
- Bump `Version` to `1.0.0`; Title Case; comma-separated `URL`; add `BugReports`
- Add Vinicius as author (`aut`); drop unused `httr` from `Suggests`

## Code / docs
- Contact the ERDDAP server over **HTTPS**
- Run cheap argument assertions **before** the network call (fail fast on bad args)
- Import `memoise` via `@importFrom`; remove dead `fix_memoise_cran_note()` and a no-op expression in `.list_layers()`
- Fix `dataset_id` docs (duplicate `phyc` entry, transposed year) and resolve redirecting URLs in man pages

## Infrastructure
- Add GitHub Actions **R-CMD-check** workflow (Linux / macOS / Windows)
- Add offline input-validation tests (`test-validation.R`)
- `NEWS` 1.0.0 section; README badges + `remotes` install; LICENSE year

## Verification
- `R CMD check --as-cran`: **0 errors, 0 warnings, 1 NOTE** (New submission — expected)
- Full test suite green over HTTPS (download, filename, list/info layers, 9 validation checks)

After CI is green, merge and tag `v1.0.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)