### PR TITLE
Set up pkgdown site + deploy workflow (#25)

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -5,3 +5,6 @@
 ^\.github$
 ^.*\.Rcheck$
 ^biooracler_.*\.tar\.gz$
+^_pkgdown\.yml$
+^docs$
+^pkgdown$

--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -1,0 +1,50 @@
+# Workflow derived from https://github.com/r-lib/actions/tree/v2/examples
+# Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
+on:
+  push:
+    branches: [main, master]
+  pull_request:
+    branches: [main, master]
+  release:
+    types: [published]
+  workflow_dispatch:
+
+name: pkgdown.yaml
+
+permissions: read-all
+
+jobs:
+  pkgdown:
+    runs-on: ubuntu-latest
+    # Only restrict concurrency for non-PR jobs
+    concurrency:
+      group: pkgdown-${{ github.event_name != 'pull_request' || github.run_id }}
+    env:
+      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: r-lib/actions/setup-pandoc@v2
+
+      - uses: r-lib/actions/setup-r@v2
+        with:
+          use-public-rspm: true
+
+      - uses: r-lib/actions/setup-r-dependencies@v2
+        with:
+          extra-packages: any::pkgdown, local::.
+          needs: website
+
+      - name: Build site
+        run: pkgdown::build_site_github_pages(new_process = FALSE, install = FALSE)
+        shell: Rscript {0}
+
+      - name: Deploy to GitHub pages 🚀
+        if: github.event_name != 'pull_request'
+        uses: JamesIves/github-pages-deploy-action@v4.5.0
+        with:
+          clean: false
+          branch: gh-pages
+          folder: docs

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -10,7 +10,7 @@ License: MIT + file LICENSE
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.3.3
-URL: https://bio-oracle.org/, https://erddap.bio-oracle.org/
+URL: https://bio-oracle.org/, https://erddap.bio-oracle.org/, https://bio-oracle.github.io/biooracler/
 BugReports: https://github.com/bio-oracle/biooracler/issues
 Suggests:
     testthat (>= 3.0.0)

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -1,0 +1,18 @@
+url: https://bio-oracle.github.io/biooracler/
+
+template:
+  bootstrap: 5
+
+reference:
+- title: Download data
+  contents:
+  - download_layers
+- title: Discover layers
+  contents:
+  - list_layers
+  - info_layer
+- title: Background
+  contents:
+  - dataset_id
+  - ERDDAP
+  - biooracler-package


### PR DESCRIPTION
Closes #25.

Adds a [`pkgdown`](https://pkgdown.r-lib.org/) documentation site.

## Changes
- `_pkgdown.yml` — Bootstrap 5 template, reference grouped into Download / Discover / Background, site URL `https://bio-oracle.github.io/biooracler/`.
- `.github/workflows/pkgdown.yaml` — builds on PRs, deploys to the `gh-pages` branch on push to `master` and on release.
- Site URL added to `DESCRIPTION` `URL:`; pkgdown artifacts added to `.Rbuildignore`.

## Verification
- `pkgdown::check_pkgdown()` → **No problems found** (every reference topic resolves).

## Follow-up (repo admin)
GitHub Pages must be enabled to serve from the **gh-pages** branch for the site to go live after the first deploy. I can't toggle that setting; it needs a maintainer (Settings → Pages → Source: `gh-pages`).

Part of the CRAN roadmap (#28).

🤖 Generated with [Claude Code](https://claude.com/claude-code)